### PR TITLE
Add comprehensive error handling for unparseable LPP sheet data

### DIFF
--- a/src/lib/ExerciseError.svelte
+++ b/src/lib/ExerciseError.svelte
@@ -1,0 +1,174 @@
+<script>
+	export let exercise;
+	
+	function formatErrorLocations(parseErrors) {
+		if (!parseErrors || parseErrors.length === 0) return '';
+		
+		const locations = parseErrors.map(error => error.location);
+		
+		if (locations.length === 1) {
+			return `cell ${locations[0]}`;
+		} else if (locations.length <= 3) {
+			return `cells ${locations.join(', ')}`;
+		} else {
+			return `${locations.length} cells (${locations.slice(0, 3).join(', ')}, ...)`;
+		}
+	}
+</script>
+
+<div class="exercise-error">
+	<div class="error-header">
+		<h2>❌ {exercise.name}</h2>
+		<span class="error-badge">Parse Error</span>
+	</div>
+	
+	<div class="error-content">
+		<div class="error-message">
+			<p>
+				<strong>Unable to display chart:</strong> 
+				Found unparseable data in {formatErrorLocations(exercise.parseErrors)} of the LPP sheet.
+			</p>
+			
+			{#if exercise.sessions && exercise.sessions.length > 0}
+				<p class="partial-data-note">
+					<em>Note: {exercise.sessions.length} session(s) with valid data were found, but the chart cannot be displayed due to parsing errors.</em>
+				</p>
+			{/if}
+		</div>
+		
+		<div class="help-text">
+			<p><strong>Expected format:</strong> "weight/reps" (e.g., "70kg/10", "15/8", "DB 20/12")</p>
+			<p><strong>Additional sets:</strong> Add " SD" to mark same-day sets (e.g., "50/15 SD")</p>
+		</div>
+	</div>
+</div>
+
+<style>
+	.exercise-error {
+		background: var(--background-card);
+		border-radius: var(--border-radius);
+		padding: 2rem;
+		box-shadow: var(--shadow-lg), var(--shadow-glow);
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		margin-bottom: 2rem;
+		backdrop-filter: blur(20px);
+		position: relative;
+		overflow: hidden;
+	}
+	
+	.exercise-error::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 4px;
+		background: linear-gradient(90deg, #ef4444, #dc2626, #b91c1c);
+	}
+	
+	.error-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 1.5rem;
+		flex-wrap: wrap;
+		gap: 1rem;
+	}
+	
+	.error-header h2 {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: 1.5rem;
+		font-weight: 700;
+	}
+	
+	.error-badge {
+		background: rgba(239, 68, 68, 0.2);
+		color: #fca5a5;
+		padding: 0.5rem 1rem;
+		border-radius: var(--border-radius-sm);
+		font-size: 0.875rem;
+		font-weight: 600;
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		backdrop-filter: blur(10px);
+	}
+	
+	.error-content {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+	
+	.error-message {
+		background: rgba(239, 68, 68, 0.1);
+		border: 1px solid rgba(239, 68, 68, 0.2);
+		border-radius: var(--border-radius-sm);
+		padding: 1.5rem;
+		backdrop-filter: blur(10px);
+	}
+	
+	.error-message p {
+		margin: 0 0 1rem 0;
+		color: #fca5a5;
+		font-weight: 500;
+		line-height: 1.5;
+	}
+	
+	.error-message p:last-child {
+		margin-bottom: 0;
+	}
+	
+	.partial-data-note {
+		color: #fbbf24 !important;
+		font-size: 0.9rem;
+	}
+	
+	.help-text {
+		background: var(--background-elevated);
+		border: 1px solid var(--border-light);
+		border-radius: var(--border-radius-sm);
+		padding: 1.5rem;
+		backdrop-filter: blur(10px);
+	}
+	
+	.help-text p {
+		margin: 0 0 0.75rem 0;
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		line-height: 1.4;
+	}
+	
+	.help-text p:last-child {
+		margin-bottom: 0;
+	}
+	
+	.help-text strong {
+		color: var(--text-primary);
+		font-weight: 600;
+	}
+	
+	/* Responsive design */
+	@media (max-width: 768px) {
+		.exercise-error {
+			padding: 1.5rem;
+		}
+		
+		.error-header {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.75rem;
+		}
+		
+		.error-header h2 {
+			font-size: 1.25rem;
+		}
+		
+		.error-content {
+			gap: 1rem;
+		}
+		
+		.error-message, .help-text {
+			padding: 1rem;
+		}
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 	import LazyChart from '$lib/LazyChart.svelte';
+	import ExerciseError from '$lib/ExerciseError.svelte';
 	
 	let exercises = {};
 	let loading = true;
@@ -106,7 +107,7 @@
 				
 				<div class="exercise-list">
 					{#each Object.entries(exercises) as [name, exercise]}
-						<label>
+						<label class:has-errors={exercise.parseErrors && exercise.parseErrors.length > 0}>
 							<input 
 								type="checkbox" 
 								checked={selectedExercises.has(name)}
@@ -114,8 +115,17 @@
 							/>
 							<span>
 								<strong>{name}</strong>
-								<small>({exercise.sessions.length} sessions)</small>
+								{#if exercise.parseErrors && exercise.parseErrors.length > 0}
+									<small class="error-info">
+										({exercise.sessions.length} sessions, {exercise.parseErrors.length} parse error{exercise.parseErrors.length > 1 ? 's' : ''})
+									</small>
+								{:else}
+									<small>({exercise.sessions.length} sessions)</small>
+								{/if}
 							</span>
+							{#if exercise.parseErrors && exercise.parseErrors.length > 0}
+								<span class="error-indicator">❌</span>
+							{/if}
 						</label>
 					{/each}
 				</div>
@@ -124,8 +134,12 @@
 		
 		<div class="charts">
 			{#each Object.entries(exercises) as [name, exercise]}
-				{#if selectedExercises.has(name) && exercise.sessions.length > 0}
-					<LazyChart {exercise} />
+				{#if selectedExercises.has(name)}
+					{#if exercise.parseErrors && exercise.parseErrors.length > 0}
+						<ExerciseError {exercise} />
+					{:else if exercise.sessions.length > 0}
+						<LazyChart {exercise} />
+					{/if}
 				{/if}
 			{/each}
 		</div>
@@ -255,6 +269,12 @@
 		font-weight: 500;
 		color: var(--text-secondary);
 		backdrop-filter: blur(10px);
+		position: relative;
+	}
+	
+	.exercise-list label.has-errors {
+		border-color: rgba(239, 68, 68, 0.3);
+		background: rgba(239, 68, 68, 0.05);
 	}
 	
 	.exercise-list label:hover {
@@ -284,6 +304,17 @@
 	
 	.exercise-list input[type="checkbox"]:checked + span strong {
 		color: var(--primary-color);
+	}
+	
+	.error-info {
+		color: #fca5a5 !important;
+		font-weight: 500;
+	}
+	
+	.error-indicator {
+		margin-left: auto;
+		font-size: 1rem;
+		opacity: 0.8;
 	}
 	
 	.charts {

--- a/src/routes/api/exercises/+server.js
+++ b/src/routes/api/exercises/+server.js
@@ -36,7 +36,8 @@ export async function GET() {
 			
 			exercises[exerciseName] = {
 				name: exerciseName,
-				sessions: []
+				sessions: [],
+				parseErrors: []
 			};
 			
 			let currentSession = null;
@@ -100,6 +101,14 @@ export async function GET() {
 							console.warn(`Found SD marker but no current session for ${exerciseName} at row ${i}`);
 						}
 					}
+				} else {
+					// Track unparseable data with location info
+					exercises[exerciseName].parseErrors.push({
+						row: i + 1, // Convert to 1-based row numbering (Google Sheets style)
+						column: String.fromCharCode(65 + j), // Convert column index to letter (A, B, C, etc.)
+						location: `${String.fromCharCode(65 + j)}${i + 1}` // e.g., "B4", "C7", etc.
+					});
+					console.log(`  Unparseable data at ${String.fromCharCode(65 + j)}${i + 1}`);
 				}
 			}
 			


### PR DESCRIPTION
- Display all exercises from LPP sheet, including those with parse errors
- Track unparseable data locations with Google Sheets cell references (e.g., B4, C7)
- Replace charts with error messages showing cell locations for problematic data
- Add visual indicators in exercise list for exercises with parse errors
- Create ExerciseError component with helpful format guidance
- Maintain security by not displaying actual unparseable data content

🤖 Generated with [Claude Code](https://claude.ai/code)