### PR TITLE
fix: Make database migrations non-interactive for Docker deployment

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,8 @@
 set -e
 
 echo "Running database migrations..."
-npm run db:push || {
+# Use --force to skip confirmation prompt and auto-approve changes
+npx drizzle-kit push --force || {
     echo "Warning: Database migration failed. This might be expected if the database is not yet available."
     echo "The application will attempt to continue, but may fail if the database schema is not up to date."
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
+    "db:push:force": "drizzle-kit push --force",
     "db:studio": "drizzle-kit studio"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed the 502 error caused by interactive migration prompts:
- Added --force flag to drizzle-kit push to auto-approve schema changes
- Updated docker-entrypoint.sh to use npx drizzle-kit push --force
- Added db:push:force npm script for manual forced migrations

This resolves the Docker deployment issue where migrations would hang waiting for user confirmation, causing the container startup to fail with HTTP 502 errors.

🤖 Generated with [Claude Code](https://claude.ai/code)